### PR TITLE
Fixes #1: Payload Size Fix

### DIFF
--- a/src/main.c
+++ b/src/main.c
@@ -418,7 +418,7 @@ void process_ipv6_transport(const u_char *packet, int packet_len,
             printf("ICMPv6 Type: %u\nICMPv6 Code: %u\n",icmp6_header.icmp6_type, icmp6_header.icmp6_code);
 
             payload = (u_char*)(packet + offset + transport_size);
-            payload_size = packet_len + (offset + transport_size);
+            payload_size = packet_len - (offset + transport_size);
             break; 
 
 


### PR DESCRIPTION
- This resolves the payload size issue that we have under the case of `IPPROTO_TCP`

When calculating `payload_size`, we need to find how many bytes remain in the packet after accounting for all headers. The correct calculation should be:

```c
payload_size = packet_len - (offset + transport_size);
```
This is because:
- `packet_len` is the total length of the packet
- `offset` is the position where the IPv6 transport header begins
- `transport_size` is the length of the transport header (`ICMPv6` in this case)

If we add these values as the code currently does:

```c
payload_size = packet_len + (offset + transport_size);  // INCORRECT
```
We're calculating a value that's larger than the entire packet, which will cause a buffer overflow when attempting to read or display that many bytes.